### PR TITLE
Fix enotices

### DIFF
--- a/Nominatim.php
+++ b/Nominatim.php
@@ -230,8 +230,8 @@ final class Nominatim extends AbstractHttpProvider implements Provider
 
         $location = $builder->build(NominatimAddress::class);
         $location = $location->withAttribution($place->licence);
-        $location = $location->withOSMId(intval($place->osm_id));
-        $location = $location->withOSMType($place->osm_type);
+        $location = $location->withOSMId(intval($place->osm_id ?? NULL));
+        $location = $location->withOSMType($place->osm_type ?? NULL);
         $location = $location->withDisplayName($place->display_name);
 
         if (false === $reverse) {


### PR DESCRIPTION
Current code expects osm_id & osm_type to be defined. However when I ran it with just a postcode they were not defined & I got an enotice  -  ie

this url
https://nominatim.openstreetmap.org/search/search?format=jsonv2&q=90210%2CUnited+States&addressdetails=1&limit=5

Gave me  this

[{"place_id":200404707,"licence":"Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright","boundingbox":["34.085763939939","34.085863939939","-118.2905153602","-118.2904153602"],"lat":"34.0858139399386","lon":"-118.290465360203","display_name":"Los Angeles, California, 90210, United States of America","place_rank":21,"category":"place","type":"postcode","importance":0.535,"address":{"city":"Los Angeles","state":"California","postcode":"90210","country":"United States of America","country_code":"us"}}]